### PR TITLE
Fix test suite

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,5 +38,5 @@ blocks:
             - chmod +x ./cc-test-reporter
             - ./cc-test-reporter before-build
             - yarn install
-            - yarn run test
+            - DB_PASSWORD="" yarn run test
             - ./cc-test-reporter after-build

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,9 +1,10 @@
-version: '3'
+version: "3"
 
 services:
   database:
     environment:
       POSTGRES_DB: bars-tracker
+      POSTGRES_PASSWORD: mysecretpassword
     image: postgres:11
     restart: always
     expose:

--- a/backend/src/configuration/database.ts
+++ b/backend/src/configuration/database.ts
@@ -9,7 +9,7 @@ const connectionOpts: ConnectionOptions = {
     host: process.env.DB_HOST || '127.0.0.1',
     port: Number(process.env.DB_PORT) || 5432,
     username: process.env.DB_USERNAME || 'postgres',
-    password: process.env.DB_PASSWORD || '',
+    password: process.env.DB_PASSWORD || 'mysecretpassword',
     database: process.env.DB_NAME || 'bars-tracker',
     entities: [
         `${parentDir}/entities/*.ts`,

--- a/backend/src/controllers/bar.controller.ts
+++ b/backend/src/controllers/bar.controller.ts
@@ -12,7 +12,7 @@ const router: Router = new Router(routerOpts);
 
 router.get('/find', async (ctx: Koa.Context) => {
     const geocoder = new Geocoder();
-    ctx.body = await geocoder.geocodeAddress({...ctx.request.body});
+    ctx.body = await geocoder.geocodeAddress({...ctx.request.body as {}});
 });
 
 router.get('/', async (ctx: Koa.Context) => {
@@ -31,7 +31,7 @@ router.get('/:bar_id', async (ctx: Koa.Context) => {
 
 router.post('/', async (ctx: Koa.Context) => {
     const bar = new Bar();
-    Object.assign(bar, {...ctx.request.body});
+    Object.assign(bar, {...ctx.request.body as {}});
     await bar.save();
 
     ctx.body = bar;


### PR DESCRIPTION
This PR fixes the test suite by forcing a type conversion for the things we read out of the Koa body.

Additionally, Postgres also wants a non-empty root password, this is reflected here as well.